### PR TITLE
Persist blocked sites and rebuild rules

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -1,47 +1,7 @@
-// Default blocked sites
-const defaultBlockedSites = [
-  'linkedin.com',
-  'hotmail.com',
-  'gmail.com',
-  'instagram.com'
-];
+document.getElementById("blockBtn").addEventListener("click", () => {
+  const domain = document.getElementById("url").value.trim();
+  if (!domain) return;
 
-// Initialize default blocked sites
-function initializeDefaultSites() {
-  defaultBlockedSites.forEach((domain, index) => {
-    chrome.declarativeNetRequest.updateDynamicRules({
-      addRules: [{
-        id: index + 1,
-        priority: 1,
-        action: { type: "block" },
-        condition: {
-          urlFilter: domain,
-          resourceTypes: ["main_frame"]
-        }
-      }]
-    });
-  });
-}
-
-// Initialize default sites when popup opens
-initializeDefaultSites();
-
-document.getElementById("blockBtn").addEventListener("click", async () => {
-    const domain = document.getElementById("url").value.trim();
-    if (!domain) return;
-  
-    const ruleId = Date.now(); // simple unique ID
-  
-    chrome.declarativeNetRequest.updateDynamicRules({
-      addRules: [{
-        id: ruleId,
-        priority: 1,
-        action: { type: "block" },
-        condition: {
-          urlFilter: domain,
-          resourceTypes: ["main_frame"]
-        }
-      }]
-    });
-  });
+  chrome.runtime.sendMessage({ action: "addSite", domain });
+});
   


### PR DESCRIPTION
## Summary
- keep the list of blocked sites in `chrome.storage.local`
- rebuild dynamic rules from stored sites when the extension starts
- provide `addSite`/`removeSite` helpers and expose them via messaging
- update the popup to send a message to add a site

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_685598a3fc6c8325be4f05433a7662b9