### PR TITLE
Update popup to show dynamic site list

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -34,6 +34,16 @@
         font-size: 12px;
         color: #666;
       }
+      #blockedList {
+        list-style-type: none;
+        padding: 0;
+      }
+      #blockedList li {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 5px;
+      }
     </style>
   </head>
   <body>
@@ -42,13 +52,8 @@
       <input id="url" placeholder="Enter domain to block (e.g., example.com)" />
       <button id="blockBtn">Block Site</button>
       <div class="blocked-sites">
-        <p>Default blocked sites:</p>
-        <ul>
-          <li>LinkedIn</li>
-          <li>Hotmail</li>
-          <li>Gmail</li>
-          <li>Instagram</li>
-        </ul>
+        <p>Blocked sites:</p>
+        <ul id="blockedList"></ul>
       </div>
     </div>
     <script src="popup.js"></script>

--- a/popup.js
+++ b/popup.js
@@ -1,7 +1,39 @@
-document.getElementById("blockBtn").addEventListener("click", () => {
-  const domain = document.getElementById("url").value.trim();
+function createListItem(site) {
+  const li = document.createElement('li');
+  li.textContent = site.domain;
+
+  const btn = document.createElement('button');
+  btn.textContent = 'Unblock';
+  btn.addEventListener('click', () => {
+    chrome.runtime.sendMessage({ action: 'removeSite', id: site.id }, () => {
+      li.remove();
+    });
+  });
+
+  li.appendChild(btn);
+  return li;
+}
+
+function loadBlockedSites() {
+  chrome.storage.local.get('blockedSites', (result) => {
+    const list = document.getElementById('blockedList');
+    list.innerHTML = '';
+    const sites = result.blockedSites || [];
+    sites.forEach(site => list.appendChild(createListItem(site)));
+  });
+}
+
+document.addEventListener('DOMContentLoaded', loadBlockedSites);
+
+document.getElementById('blockBtn').addEventListener('click', () => {
+  const domain = document.getElementById('url').value.trim();
   if (!domain) return;
 
-  chrome.runtime.sendMessage({ action: "addSite", domain });
+  chrome.runtime.sendMessage({ action: 'addSite', domain }, (response) => {
+    if (response && response.success) {
+      document.getElementById('url').value = '';
+      loadBlockedSites();
+    }
+  });
 });
   


### PR DESCRIPTION
## Summary
- render blocked sites dynamically in `popup.html`
- display list of sites with `Unblock` buttons
- update `popup.js` to load blocked sites and message background script when adding/removing

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_b_68559961f86c8325a917d7410d5fe02b