### PR TITLE
Add basic test suite

### DIFF
--- a/background.js
+++ b/background.js
@@ -114,4 +114,17 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     return true;
   }
 });
+
+// Support Node.js testing by exporting functions
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    buildRules,
+    addSite,
+    removeSite,
+    loadStoredSites,
+    defaultBlockedSites,
+    STORAGE_KEY,
+    NEXT_ID_KEY
+  };
+}
   

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "web-blocker",
+  "version": "1.0.0",
+  "description": "Brutal Site Blocker tests",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/test/background.test.js
+++ b/test/background.test.js
@@ -1,0 +1,74 @@
+const assert = require('node:assert/strict');
+const { test, beforeEach } = require('node:test');
+
+function createChromeMock() {
+  return {
+    storage: {
+      local: {
+        _store: {},
+        async get(keys) {
+          if (Array.isArray(keys)) {
+            const res = {};
+            for (const k of keys) res[k] = this._store[k];
+            return res;
+          }
+          return { [keys]: this._store[keys] };
+        },
+        async set(obj) {
+          Object.assign(this._store, obj);
+        }
+      }
+    },
+    declarativeNetRequest: {
+      calls: [],
+      async updateDynamicRules(args) {
+        this.calls.push(args);
+      }
+    },
+    runtime: {
+      onInstalled: { addListener() {} },
+      onStartup: { addListener() {} },
+      onMessage: { addListener() {} }
+    }
+  };
+}
+
+let bg;
+
+beforeEach(() => {
+  global.chrome = createChromeMock();
+  delete require.cache[require.resolve('../background.js')];
+  bg = require('../background.js');
+});
+
+test('addSite adds a domain and updates rules', async () => {
+  const store = global.chrome.storage.local._store;
+  store[bg.STORAGE_KEY] = [];
+  store[bg.NEXT_ID_KEY] = 1;
+
+  await bg.addSite('example.com');
+
+  assert.deepEqual(store[bg.STORAGE_KEY], [{ id: 1, domain: 'example.com' }]);
+  assert.equal(store[bg.NEXT_ID_KEY], 2);
+
+  const calls = global.chrome.declarativeNetRequest.calls;
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].addRules[0].id, 1);
+  assert.equal(calls[0].addRules[0].condition.urlFilter, 'example.com');
+});
+
+test('removeSite removes a domain and updates rules', async () => {
+  const store = global.chrome.storage.local._store;
+  store[bg.STORAGE_KEY] = [
+    { id: 1, domain: 'example.com' },
+    { id: 2, domain: 'test.com' }
+  ];
+
+  await bg.removeSite(1);
+
+  assert.deepEqual(store[bg.STORAGE_KEY], [{ id: 2, domain: 'test.com' }]);
+
+  const calls = global.chrome.declarativeNetRequest.calls;
+  assert.equal(calls.length, 1);
+  assert.deepEqual(calls[0].removeRuleIds, [1]);
+});


### PR DESCRIPTION
## Summary
- export functions from `background.js` when running in Node
- add a minimal `package.json` with a Node test script
- write Node-based tests for adding/removing blocked sites using a mocked `chrome`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6855a80d47fc8325a5a4b9c6ce0e1bbf